### PR TITLE
Status is sent with the broadcasts but it is never defined.

### DIFF
--- a/services_API.js
+++ b/services_API.js
@@ -122,7 +122,7 @@ angular.module( "vokal.API", [ "vokal.Humps" ] )
 
             $http( options )
 
-                .success( function ( data )
+                .success( function ( data, status )
                 {
                     $rootScope.$broadcast( "APIRequestComplete", options, data, status );
                     $rootScope.$broadcast( "APIRequestSuccess",  options, data, status );


### PR DESCRIPTION
Complete/success broadcasts don't have access to status.

@jrit 
